### PR TITLE
edit goose string isnde docker entry point

### DIFF
--- a/expense-tracker-api/docker-compose.production.yml
+++ b/expense-tracker-api/docker-compose.production.yml
@@ -7,17 +7,18 @@ services:
     ports:
       - '8080:8080'
     environment:
-      GOOSE_DBSTRING: postgres://${DB_USER}:${DB_PASSWORD}@postgres_db:5432/${DB_NAME}?sslmode=disable
+      GOOSE_DBSTRING: postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_NAME}?sslmode=disable
     entrypoint: ['/bin/sh', '-c']
     command:
       - |
         echo "Waiting for database to be ready..."
         sleep 5
+        export GOOSE_DRIVER=postgres
         echo "Running database migrations with Goose..."
         goose -version
         echo "Using connection string: $$GOOSE_DBSTRING"
-        goose -dir /app/db/migrations status
-        goose -dir /app/db/migrations up
+        goose status
+        goose up
         echo "Migrations applied."
         echo "Starting application..."
         exec /app/bin/api

--- a/expense-tracker-api/docker-entrypoint.sh
+++ b/expense-tracker-api/docker-entrypoint.sh
@@ -8,7 +8,8 @@ sleep 5
 # Run the goose migrations
 echo "Running database migrations with Goose..."
 export GOOSE_DRIVER=postgres
-export GOOSE_DBSTRING=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+export GOOSE_DBSTRING=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=disable
+entrypoint: ['/bin/sh', '-c']
 goose -version
 echo "Using connection string: ${GOOSE_DBSTRING}"
 goose status

--- a/expense-tracker-api/docker-entrypoint.sh
+++ b/expense-tracker-api/docker-entrypoint.sh
@@ -8,7 +8,7 @@ sleep 5
 # Run the goose migrations
 echo "Running database migrations with Goose..."
 export GOOSE_DRIVER=postgres
-export GOOSE_DBSTRING=postgres://${DB_USER}:${DB_PASSWORD}@postgres_db:5432/${DB_NAME}?sslmode=disable
+export GOOSE_DBSTRING=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
 goose -version
 echo "Using connection string: ${GOOSE_DBSTRING}"
 goose status


### PR DESCRIPTION
This pull request updates how the Goose database migration tool is configured in both the Docker Compose production file and the entrypoint script. The main focus is on improving database connection flexibility and simplifying migration commands.

**Database configuration improvements:**

* Changed the Goose database connection string in both `docker-compose.production.yml` and `docker-entrypoint.sh` to use `${DB_HOST}` (and `${DB_PORT}` in the entrypoint) instead of hardcoding the host and port, allowing for more flexible deployment configurations. [[1]](diffhunk://#diff-d30dc7451bb8017aea1bf0917ea4adb2be962e491c9d87cbf10407036a5d68e0L10-R21) [[2]](diffhunk://#diff-e7dcb3350ab53fad7c84ea43d6c266b8f14b6aca9e67a5a027de05946fe33d04L11-R11)
* Added explicit export of `GOOSE_DRIVER=postgres` in the Docker Compose entrypoint to ensure the correct database driver is set for migrations.

**Migration command simplification:**

* Simplified Goose migration commands by removing the explicit `-dir /app/db/migrations` argument, assuming the default directory is used, and by streamlining the migration process to just `goose status` and `goose up`.